### PR TITLE
Fixed /v1/log to work with Apple's push

### DIFF
--- a/index.php
+++ b/index.php
@@ -149,11 +149,10 @@ else if ($function == "push") { //pushes a notification
 	}
 }
 else if ($function == "log") { //writes a log message
-	$title = $_REQUEST["title"];
-	$body = $_REQUEST["body"];
-	$log = json_decode($body);
+	$cont = file_get_contents('php://input');	
+	$log = json_decode($cont);	
 	$fp = fopen('logs/request.log', 'a');
-	fwrite($fp, $log['logs']);
+	fwrite($fp, implode("\n", $log->logs)."\n");
 	fclose($fp);
 }
 else if ($function == "list") { //return a list of subscribers


### PR DESCRIPTION
According to

https://developer.apple.com/library/prerelease/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW1

a call such as

curl -X POST -H "Content-Type: body=application/json" -d '{"logs":["foo", "bar"]}' https://example.com/v1/log

will be sent. The previous code would have never make it happen.
